### PR TITLE
Fixed a bug where z would be incorrectly calculated for diagonally asymmetric transition matrices

### DIFF
--- a/R/LagSeq_function.R
+++ b/R/LagSeq_function.R
@@ -56,7 +56,7 @@ LagSeq <- function(vec, ncodes=0, lag=1, merge=FALSE) {
   
   ## Expected frequency matrix and Adjusted residuals
   rowtots  = rowSums(freqs) # sums of rows
-  coltots  = rowSums(freqs) # sums of cols
+  coltots  = rowCols(freqs) # sums of cols
   ntrans   = sum(rowtots) # total transitions
   prows    = rowtots / ntrans # probability for each row
   pcols    = coltots / ntrans # probability for each column

--- a/R/LagSeq_function.R
+++ b/R/LagSeq_function.R
@@ -56,7 +56,7 @@ LagSeq <- function(vec, ncodes=0, lag=1, merge=FALSE) {
   
   ## Expected frequency matrix and Adjusted residuals
   rowtots  = rowSums(freqs) # sums of rows
-  coltots  = rowCols(freqs) # sums of cols
+  coltots  = colSums(freqs) # sums of cols
   ntrans   = sum(rowtots) # total transitions
   prows    = rowtots / ntrans # probability for each row
   pcols    = coltots / ntrans # probability for each column


### PR DESCRIPTION
I noticed that row totals and column totals were both calculated as row totals in `LagSeq_function.R`. I believe this will only work correctly in the special case where row totals and column totals are the same. I was able to verify that the results seem incorrect with a simple test sequence: `1, 1, 2, 2`, which results in this transition matrix:

```
 --- ---
| 1 | 1 |
 --- ---
| 0 | 1 |
 --- ---
```

The z-score of the 1->2 transition should be:

`z = (1 - 2*2/3) / sqrt(2*2/3 * (1 - 2 / 3) * (1 - 2 / 3)) = -0.866`

But the actual result was +0.866. The z-scores for the other transitions were incorrect as well. This pull request fixes that.